### PR TITLE
Adopt Swift 5

### DIFF
--- a/Sources/XCTest+watchOS.swift
+++ b/Sources/XCTest+watchOS.swift
@@ -229,45 +229,45 @@ public class XCTestExpectation {
 public func XCTAssertTrue(_ expression: @autoclosure () throws -> Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     do {
         let result = try expression()
-        assert(result, message, file: file, line: line)
+        assert(result, message(), file: file, line: line)
     } catch _ {
-        assertionFailure(message, file: file, line: line)
+        assertionFailure(message(), file: file, line: line)
     }
 }
 
 public func XCTAssertFalse(_ expression: @autoclosure () throws -> Bool, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     do {
         let result = try expression()
-        assert(!result, message, file: file, line: line)
+        assert(!result, message(), file: file, line: line)
     } catch _ {
-        assertionFailure(message, file: file, line: line)
+        assertionFailure(message(), file: file, line: line)
     }
 }
 
 public func XCTAssertNil(_ expression: @autoclosure () throws -> Any?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     do {
         let result = try expression()
-        assert(result == nil, message, file: file, line: line)
+        assert(result == nil, message(), file: file, line: line)
     } catch _ {
-        assertionFailure(message, file: file, line: line)
+        assertionFailure(message(), file: file, line: line)
     }
 }
 
 public func XCTAssertEqual<T: Equatable>(_ expression1: @autoclosure () throws -> T?, _ expression2: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     do {
         let (value1, value2) = (try expression1(), try expression2())
-        assert(value1 == value2, message, file: file, line: line)
+        assert(value1 == value2, message(), file: file, line: line)
     } catch _ {
-        assertionFailure(message, file: file, line: line)
+        assertionFailure(message(), file: file, line: line)
     }
 }
 
 public func XCTAssertNotEqual<T: Equatable>(_ expression1: @autoclosure () throws -> T, _ expression2: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
     do {
         let (value1, value2) = (try expression1(), try expression2())
-        assert(value1 != value2, message, file: file, line: line)
+        assert(value1 != value2, message(), file: file, line: line)
     } catch _ {
-        assertionFailure(message, file: file, line: line)
+        assertionFailure(message(), file: file, line: line)
     }
 }
 

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -312,7 +312,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -98,7 +98,7 @@
 				TargetAttributes = {
 					16A0D5B92134D43E008D852B = {
 						CreatedOnToolsVersion = 9.4.1;
-						LastSwiftMigration = 0940;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -284,7 +284,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Debug;
@@ -312,7 +312,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;

--- a/XCTest.xcodeproj/project.pbxproj
+++ b/XCTest.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 16A0D5B02134D43E008D852B;
 			productRefGroup = 16A0D5BB2134D43E008D852B /* Products */;


### PR DESCRIPTION
With backwards-compatible source changes. I tested building with Swift 4, Swift 4.2, and Swift 5.

PTAL @ericmuller22 @nickentin @martinmroz