### PR TITLE
Remove unnecessary version from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,4 +21,3 @@ let package = Package(
     ],
     swiftLanguageVersions: [.v4, .v4_2, .v5]
 )
-let version = Version(0, 0, 1)


### PR DESCRIPTION
The version can be inferred from the current tag.